### PR TITLE
Minor updates to redis setup.

### DIFF
--- a/config/redis.conf
+++ b/config/redis.conf
@@ -58,7 +58,7 @@
 # IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
 # JUST COMMENT THE FOLLOWING LINE.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# bind 127.0.0.1
+bind 127.0.0.1
 
 # Protected mode is a layer of security protection, in order to avoid that
 # Redis instances left open on the internet are accessed and exploited.
@@ -81,7 +81,8 @@
 
 # Accept connections on the specified port, default is 6379 (IANA #815344).
 # If port 0 is specified Redis will not listen on a TCP socket.
-port 6379
+# port 6379
+port 0
 
 # TCP listen() backlog.
 #
@@ -100,6 +101,8 @@ tcp-backlog 511
 #
 # unixsocket /tmp/redis.sock
 # unixsocketperm 700
+unixsocket /tmp/redis.sock
+unixsocketperm 700
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout 0
@@ -175,7 +178,8 @@ logfile /var/log/redis/redis.log
 # Set the number of databases. The default database is DB 0, you can select
 # a different one on a per-connection basis using SELECT <dbid> where
 # dbid is a number between 0 and 'databases'-1
-databases 16
+# databases 16
+databases 513
 
 ################################ SNAPSHOTTING  ################################
 #
@@ -199,7 +203,7 @@ databases 16
 #
 #   save ""
 
-# 
+# Using save statements causing a freeze/hang in the connection between openvas-scanner to redis
 #save 900 1
 #save 300 10
 #save 60 10000
@@ -1051,5 +1055,3 @@ hz 10
 # in order to commit the file to the disk more incrementally and avoid
 # big latency spikes.
 aof-rewrite-incremental-fsync yes
-unixsocket /tmp/redis.sock
-unixsocketperm 700

--- a/run.sh
+++ b/run.sh
@@ -12,11 +12,11 @@ CA_FILE=/var/lib/openvas/CA/cacert.pem
 redis-server /etc/redis.conf &
 
 echo "Testing redis status..."
-X="$(redis-cli ping)"
+X="$(redis-cli -s /tmp/redis.sock ping)"
 while  [ "${X}" != "PONG" ]; do
         echo "Redis not yet ready..."
         sleep 1
-        X="$(redis-cli ping)"
+        X="$(redis-cli -s /tmp/redis.sock ping)"
 done
 echo "Redis ready."
 


### PR DESCRIPTION
This is a follow-up of https://github.com/Atomicorp/openvas-docker/commit/18065fe4fd2b924bba0a1b5468b38e537c85d8cc:

- Commenting out the bind part just made redis to listen on all interfaces like explained one line above, not to only listen on a unix socket
- Setting port 0 so listening on a TCP socket is skipped
- Moving the socket stuff to the part where the description is located
- Raise the databases to match whats suggested in https://wald.intevation.org/scm/viewvc.php/trunk/openvas-scanner/doc/example_redis_2_6.conf.in?root=openvas&view=markup
- Explain why the save statements are commented out
- Add the path to the redis-cli command which needs to point to the socket after the changes above